### PR TITLE
fix bug

### DIFF
--- a/markjs/src/plugins/scale.js
+++ b/markjs/src/plugins/scale.js
@@ -16,14 +16,14 @@ export default function EditPlugin(instance, utils) {
   let maxScale = 10;
 
   // 重写toCanvasPos方法
-  let originToCanvasPos = instance.toCanvasPos.bind(instance);
-  instance.toCanvasPos = (e) => {
-    let res = originToCanvasPos(e);
-    return {
-      x: res.x / scale,
-      y: res.y / scale,
-    };
-  };
+  // let originToCanvasPos = instance.toCanvasPos.bind(instance);
+  // instance.toCanvasPos = (e) => {
+  //   let res = originToCanvasPos(e);
+  //   return {
+  //     x: res.x / scale,
+  //     y: res.y / scale,
+  //   };
+  // };
 
   // 鼠标滚动事件
   instance.el.addEventListener("wheel", (e) => {


### PR DESCRIPTION
https://github.com/wanglin2/markjs/blob/1638e41d6c077b0d6a18c115972d4b23249c0f15/markjs/index.js#L429-L430
修复缩放模式坐标偏移的问题，偏移重复处理了